### PR TITLE
Fix CLI usage error

### DIFF
--- a/fastsolv/fastsolv/_cli.py
+++ b/fastsolv/fastsolv/_cli.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 from importlib.metadata import version
 
 import pandas as pd
@@ -8,16 +9,64 @@ from ._module import fastsolv
 
 def _fastsolv_predict(parser=None):
     if parser is None:
-        parser = argparse.ArgumentParser(description="fastsolv command line interface - try 'fastsolv --help'")
-        parser.add_argument("-v", "--version", help="print version and exit", action="store_true")
-        parser.add_argument("input", nargs=1, help="CSV file containing 'solvent_smiles', 'solute_smiles', and 'temperature' in Kelvin.")
-        parser.add_argument("-o", "--output", help="Name of output file", default="fastsolv_output.csv")
+        parser = argparse.ArgumentParser(
+            description="fastsolv solid solubility predictor CLI.",
+            epilog="Example: fastsolv input.csv -o predictions.csv",
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter 
+        )
+        parser.add_argument(
+            "-v", "--version",
+            action="store_true",
+            help="Print the version of fastsolv and exit."
+        )
+        parser.add_argument(
+            "input",
+            nargs='?',  
+            default=None, 
+            help="Path to the input CSV file. Required unless --version is used. "
+                 "The CSV must contain 'solvent_smiles', 'solute_smiles', and 'temperature' (in Kelvin) columns."
+        )
+        parser.add_argument(
+            "-o", "--output",
+            default="fastsolv_output.csv",
+            help="Path to save the output CSV file."
+        )
 
     args = parser.parse_args()
-    if args.version:
-        print(version("fastsolv"))
-        exit(0)
 
-    df = pd.read_csv(args.input)
-    out = fastsolv(df)
-    out.to_csv(args.output)
+    if args.version:
+        print(f"fastsolv version {version('fastsolv')}")
+        sys.exit(0)
+
+    # If not asking for version, input file is mandatory
+    if args.input is None:
+        parser.error("the following arguments are required: input (path to CSV file)")
+
+    required_columns = ['solvent_smiles', 'solute_smiles', 'temperature']
+
+    try:
+        df = pd.read_csv(args.input)
+
+        if df.empty:
+            print(f"Error: The input file '{args.input}' is empty.")
+            sys.exit(1)
+
+        missing_columns = [col for col in required_columns if col not in df.columns]
+        if missing_columns:
+            print(f"Error: The input file '{args.input}' is missing the following required columns: {', '.join(missing_columns)}.")
+            sys.exit(1)
+
+        print(f"Processing '{args.input}'...")
+        out_df = fastsolv(df)
+        out_df.to_csv(args.output, index=False)
+        print(f"Predictions saved to '{args.output}'.")
+
+    except FileNotFoundError:
+        print(f"Error: The input file '{args.input}' was not found.")
+        sys.exit(1)
+    except pd.errors.ParserError:
+        print(f"Error: Could not parse the CSV file '{args.input}'. Please ensure it is a valid CSV.")
+        sys.exit(1)
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+        sys.exit(1)

--- a/fastsolv/fastsolv/_cli.py
+++ b/fastsolv/fastsolv/_cli.py
@@ -35,7 +35,7 @@ def _fastsolv_predict(parser=None):
     args = parser.parse_args()
 
     if args.version:
-        print(f"fastsolv version {version('fastsolv')}")
+        printversion("fastsolv"))
         sys.exit(0)
 
     # If not asking for version, input file is mandatory

--- a/fastsolv/fastsolv/_cli.py
+++ b/fastsolv/fastsolv/_cli.py
@@ -12,7 +12,7 @@ def _fastsolv_predict(parser=None):
         parser = argparse.ArgumentParser(
             description="fastsolv solid solubility predictor CLI.",
             epilog="Example: fastsolv input.csv -o predictions.csv",
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter 
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter
         )
         parser.add_argument(
             "-v", "--version",
@@ -21,8 +21,8 @@ def _fastsolv_predict(parser=None):
         )
         parser.add_argument(
             "input",
-            nargs='?',  
-            default=None, 
+            nargs='?',
+            default=None,
             help="Path to the input CSV file. Required unless --version is used. "
                  "The CSV must contain 'solvent_smiles', 'solute_smiles', and 'temperature' (in Kelvin) columns."
         )
@@ -35,7 +35,7 @@ def _fastsolv_predict(parser=None):
     args = parser.parse_args()
 
     if args.version:
-        printversion("fastsolv"))
+        print(version("fastsolv"))
         sys.exit(0)
 
     # If not asking for version, input file is mandatory

--- a/fastsolv/pyproject.toml
+++ b/fastsolv/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fastsolv"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
     { name = "Jackson Burns" },
 ]

--- a/fastsolv/pyproject.toml
+++ b/fastsolv/pyproject.toml
@@ -22,7 +22,7 @@ file = "README.md"
 content-type = "text/markdown"
 
 [project.scripts]
-fastsolv = "fastsolv:fastsolv_predict"
+fastsolv = "fastsolv._cli:_fastsolv_predict"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
For using the command line tool, the module path in the `pyproject.toml` was not set correctly which lead to an import error upon execution. Furthermore, it was not possible to call `fastsolv -v` without providing an input, which is fixed now.